### PR TITLE
Updated AUR Packages Section

### DIFF
--- a/pages/getting-started/1-installation.mdx
+++ b/pages/getting-started/1-installation.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Installation
 
 The preferred way of installing Lune is using [Aftman](https://github.com/lpghatguy/aftman).
@@ -24,17 +26,28 @@ when installing here.
 <details>
 <summary>Community-maintained</summary>
 
-### ArchLinux User Repository
+### AUR (Arch User Repository)
+There are a number of packages available on the AUR:
+
+- `lune` - Builds from the latest stable release source. 
+- `lune-git` - Builds from the latest commit in the repo; unstable.
+- `lune-bin` - Installs a precompiled binary from GitHub Release artifacts.
+
+These can be installed with your favourite AUR manager as such:
 
 ```sh copy filename="Bash"
-paru -S lune
+paru -S [PACKAGE_NAME]
 ```
 
 ***or***
 
 ```sh copy filename="Bash"
-yay -S lune
+yay -S [PACKAGE_NAME]
 ```
+
+<Callout type="warning" emoji="⚠️">
+  Only one of these AUR packages must be installed at a time in order to prevent conflicts.
+</Callout>
 
 </details>
 


### PR DESCRIPTION
As there are multiple AUR packages for Lune now (lune, lune-git, and lune-bin), I've included them in the docs in order to clarify what their purposes are. This way, installation is more accessible and feels "native" to the end user.

![updated AUR section](https://github.com/lune-org/docs/assets/74418041/518b1b42-1d09-48a6-b794-79d1f53121be)

