### PR TITLE
Include Scoop Package Section

### DIFF
--- a/pages/getting-started/1-installation.mdx
+++ b/pages/getting-started/1-installation.mdx
@@ -49,6 +49,17 @@ yay -S [PACKAGE_NAME]
   Only one of these AUR packages must be installed at a time in order to prevent conflicts.
 </Callout>
 
+
+### Scoop
+Windows users can use [scoop](https://scoop.sh) to install lune.
+
+```ps copy filename="PowerShell"
+# Add the bucket
+scoop bucket add lune https://github.com/CompeyDev/lune-packaging.git
+
+# Install the package
+scoop install lune
+```
 </details>
 
 <details>
@@ -60,17 +71,6 @@ your system. <br /> Once installed, run the following command in your terminal:
 
 ```sh copy filename="Bash"
 cargo install lune --locked
-```
-
-### Scoop
-Windows users can use [scoop](https://scoop.sh) to install lune.
-
-```ps copy filename="PowerShell"
-# Add the bucket
-scoop bucket add lune https://github.com/CompeyDev/lune-packaging.git
-
-# Install the package
-scoop install lune
 ```
 </details>
 

--- a/pages/getting-started/1-installation.mdx
+++ b/pages/getting-started/1-installation.mdx
@@ -62,6 +62,16 @@ your system. <br /> Once installed, run the following command in your terminal:
 cargo install lune --locked
 ```
 
+### Scoop
+Windows users can use [scoop](https://scoop.sh) to install lune.
+
+```ps copy filename="PowerShell"
+# Add the bucket
+scoop bucket add lune https://github.com/CompeyDev/lune-packaging.git
+
+# Install the package
+scoop install lune
+```
 </details>
 
 ## Next Steps


### PR DESCRIPTION
I've created a [scoop](https://scoop.sh) package at [CompeyDev/lune-packaging](https://github.com/CompeyDev?tab=repositories). Scoop is a package manager similar to chocolatey for Windows users.

This PR updates the docs to include steps to install lune using scoop.