### PR TITLE
Include `cargo binstall` docs

### DIFF
--- a/pages/getting-started/1-installation.mdx
+++ b/pages/getting-started/1-installation.mdx
@@ -95,8 +95,9 @@ yay -S [PACKAGE_NAME]
 </details>
 
 <details>
-<summary>Building from source</summary>
+<summary>crates.io</summary>
 
+### Building from source
 Building and installing from source requires the latest version of
 [Rust & Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) to be installed on
 your system. <br /> Once installed, run the following command in your terminal:
@@ -104,6 +105,16 @@ your system. <br /> Once installed, run the following command in your terminal:
 ```sh copy filename="Bash"
 cargo install lune --locked
 ```
+### Binstall
+`cargo binstall` provides a simple mechanism for installing rust binaries from crates.io, without
+compiling from source unlike `cargo install`. Lune is packaged in a `binstall` compatible way.
+
+With `binstall` installed and in your path, run:
+```sh copy filename="Bash"
+cargo binstall lune
+```
+
+
 </details>
 
 ## Next Steps

--- a/pages/getting-started/1-installation.mdx
+++ b/pages/getting-started/1-installation.mdx
@@ -106,7 +106,7 @@ your system. <br /> Once installed, run the following command in your terminal:
 cargo install lune --locked
 ```
 ### Binstall
-`cargo binstall` provides a simple mechanism for installing rust binaries from crates.io, without
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) provides a simple mechanism for installing rust binaries from crates.io, without
 compiling from source unlike `cargo install`. Lune is packaged in a `binstall` compatible way.
 
 With `binstall` installed and in your path, run:


### PR DESCRIPTION
This PR renames the "Building from source" section to "crates.io", and includes methods to install lune from its published crate by using both `cargo install` & `cargo binstall`.

### What is `cargo binstall`?

From their [README](https://github.com/cargo-bins/cargo-binstall#readme):
> `cargo binstall` provides a low-complexity mechanism for installing rust binaries as an alternative to building from source (via `cargo install`) or manually downloading packages. This is intended to work with existing CI artifacts and infrastructure, and with minimal overhead for package maintainers.
