### PR TITLE
Add favicon to head tag

### DIFF
--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -34,4 +34,9 @@ export default {
 			/>
 		</>
 	),
+	head: (
+		<>
+			<link rel="icon" href="https://github.com/lune-org/lune/raw/main/assets/logo/tilt.png" type="image/png" />
+		</>
+	)
 }


### PR DESCRIPTION
Now it is able to see clearly lune docs among the many Chrome tabs

![image](https://github.com/user-attachments/assets/05d24139-6d52-42f4-a76b-8ad86cc64862)
