### PR TITLE
Fix example code error in Getting Started > Introduction > 4 • Script Arguments

### DIFF
--- a/pages/getting-started/2-introduction/4-script-arguments.md
+++ b/pages/getting-started/2-introduction/4-script-arguments.md
@@ -34,7 +34,7 @@ elseif #process.args > 0 then
 	print(process.args)
 else
 	print("Got no arguments ☹️")
-	local prompted = stdio.prompt("Please enter some text:")
+	local prompted = stdio.prompt("text", "Please enter some text:")
 	print("Got prompted text:", prompted)
 end
 ```


### PR DESCRIPTION
```luau
local process = require("@lune/process")
local stdio = require("@lune/stdio")
 
if #process.args > 3 then
	error("Too many arguments!")
elseif #process.args > 0 then
	print("Got arguments:")
	print(process.args)
else
	print("Got no arguments ☹️")
	local prompted = stdio.prompt("Please enter some text:") -- error
	print("Got prompted text:", prompted)
end
```

'error' line is missing PromptKind arg. Fixed by passing 'text'.